### PR TITLE
Ajout des organization

### DIFF
--- a/frontend/src/resources/Event/EventFilterSidebar.js
+++ b/frontend/src/resources/Event/EventFilterSidebar.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FilterLiveSearch } from 'react-admin';
+import { Card, CardContent, makeStyles } from '@material-ui/core';
+import { ReferenceFilter } from '@semapps/archipelago-layout';
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    paddingTop: 0,
+    [theme.breakpoints.up('sm')]: {
+      minWidth: '15em',
+      marginLeft: '1em',
+    },
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  }
+}));
+
+const EventFilterSidebar = () => {
+  const classes = useStyles();
+  return (
+    <Card className={classes.card}>
+      <CardContent>
+        <FilterLiveSearch />
+        <ReferenceFilter reference="Organization" source="pair:operatedBy" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default EventFilterSidebar;

--- a/frontend/src/resources/Event/EventForm.js
+++ b/frontend/src/resources/Event/EventForm.js
@@ -3,6 +3,7 @@ import { required, SimpleForm, TextInput } from 'react-admin';
 import MarkdownInput from '../../markdown/MarkdownInput';
 import { DateTimeInput } from '@semapps/date-components';
 import frLocale from "date-fns/locale/fr";
+import ReferenceQuickCreateInput from "../../pair/ReferenceQuickCreateInput";
 
 const urlValidation = (value) => {
   if (value && !value.startsWith('http://') && !value.startsWith('https://')) {
@@ -14,6 +15,30 @@ const urlValidation = (value) => {
 const EventForm = props => (
   <SimpleForm {...props} redirect="show">
     <TextInput source="pair:label" validate={required()} fullWidth />
+    <ReferenceQuickCreateInput
+      reference="Organization"
+      source="pair:operatedBy"
+      selectOptionText="pair:label"
+      perPage={1000}
+    >
+      <TextInput
+        label="Nom"
+        source="pair:label"
+        validate={required()}
+        fullWidth
+      />
+      <TextInput
+        label="Lien vers le site de l'organisation"
+        source="pair:webPage"
+        fullWidth
+      />
+      <MarkdownInput
+        multiline
+        label="Lien vers le site de l'organisation"
+        source="pair:description"
+        fullWidth
+      />
+    </ReferenceQuickCreateInput>
     <MarkdownInput multiline source="pair:description" fullWidth />
     <DateTimeInput
       source="pair:startDate"

--- a/frontend/src/resources/Event/EventForm.js
+++ b/frontend/src/resources/Event/EventForm.js
@@ -34,7 +34,7 @@ const EventForm = props => (
       />
       <MarkdownInput
         multiline
-        label="Lien vers le site de l'organisation"
+        helperText="Description de votre organisation"
         source="pair:description"
         fullWidth
       />

--- a/frontend/src/resources/Event/EventList.js
+++ b/frontend/src/resources/Event/EventList.js
@@ -3,11 +3,18 @@ import { DateField } from 'react-admin';
 import { Avatar } from '@material-ui/core';
 import { List, SimpleList, ListActions } from '@semapps/archipelago-layout';
 import EventIcon from '@material-ui/icons/Event';
+import EventFilterSidebar from './EventFilterSidebar';
 
 const EventList = props => (
-  <List title="Calendrier" sort={{ field: 'pair:startDate', order: 'DESC' }} actions={<ListActions exporter={false} />} {...props}>
+  <List
+    title="Calendrier"
+    aside={<EventFilterSidebar />}
+    sort={{ field: "pair:startDate", order: "DESC" }}
+    actions={<ListActions exporter={false} />}
+    {...props}
+  >
     <SimpleList
-      primaryText={record => record['pair:label']}
+      primaryText={record => record["pair:label"]}
       secondaryText={record => (
         <>
           Du&nbsp;

--- a/frontend/src/resources/Event/EventList.js
+++ b/frontend/src/resources/Event/EventList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DateField } from 'react-admin';
+import { DateField, ReferenceField, TextField } from 'react-admin';
 import { Avatar } from '@material-ui/core';
 import { List, SimpleList, ListActions } from '@semapps/archipelago-layout';
 import EventIcon from '@material-ui/icons/Event';
@@ -16,6 +16,18 @@ const EventList = props => (
     <SimpleList
       primaryText={record => record["pair:label"]}
       secondaryText={record => (
+          <ReferenceField
+            record={record}
+            reference="Organization"
+            basePath="Organization" // Hack to get access to to Organization data
+            source="pair:operatedBy"
+            linkType="show"
+          >
+            <TextField source="pair:label" />
+          </ReferenceField>
+        )
+      }
+      tertiaryText={(record) => (
         <>
           Du&nbsp;
           <DateField record={record} source="pair:startDate" showTime />

--- a/frontend/src/resources/Event/EventList.js
+++ b/frontend/src/resources/Event/EventList.js
@@ -30,9 +30,29 @@ const EventList = props => (
       tertiaryText={(record) => (
         <>
           Du&nbsp;
-          <DateField record={record} source="pair:startDate" showTime />
+          <DateField
+            record={record}
+            source="pair:startDate"
+            options={{
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            }}
+          />
           &nbsp;au&nbsp;
-          <DateField record={record} source="pair:endDate" showTime />
+          <DateField
+            record={record}
+            source="pair:endDate"
+            options={{
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+            }}
+          />
         </>
       )}
       leftAvatar={() =>

--- a/frontend/src/resources/Event/EventList.js
+++ b/frontend/src/resources/Event/EventList.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { DateField, ReferenceField, TextField } from 'react-admin';
+import { ReferenceField, TextField } from 'react-admin';
 import { Avatar } from '@material-ui/core';
 import { List, SimpleList, ListActions } from '@semapps/archipelago-layout';
 import EventIcon from '@material-ui/icons/Event';
 import EventFilterSidebar from './EventFilterSidebar';
+import isSameDay from 'date-fns/isSameDay';
+import format from 'date-fns/format';
 
 const EventList = props => (
   <List
@@ -16,50 +18,57 @@ const EventList = props => (
     <SimpleList
       primaryText={record => record["pair:label"]}
       secondaryText={record => (
-          <ReferenceField
-            record={record}
-            reference="Organization"
-            basePath="Organization" // Hack to get access to to Organization data
-            source="pair:operatedBy"
-            linkType="show"
-          >
-            <TextField source="pair:label" />
-          </ReferenceField>
-        )
-      }
-      tertiaryText={(record) => (
-        <>
-          Du&nbsp;
-          <DateField
-            record={record}
-            source="pair:startDate"
-            options={{
-              year: "numeric",
-              month: "2-digit",
-              day: "2-digit",
-              hour: "2-digit",
-              minute: "2-digit",
-            }}
-          />
-          &nbsp;au&nbsp;
-          <DateField
-            record={record}
-            source="pair:endDate"
-            options={{
-              year: "numeric",
-              month: "2-digit",
-              day: "2-digit",
-              hour: "2-digit",
-              minute: "2-digit",
-            }}
-          />
-        </>
+        <ReferenceField
+          record={record}
+          reference="Organization"
+          basePath="Organization" // Hack to get access to to Organization data
+          source="pair:operatedBy"
+          linkType="show"
+        >
+          <TextField source="pair:label" />
+        </ReferenceField>
       )}
-      leftAvatar={() =>
+      tertiaryText={record => {
+        if (record["pair:startDate"] && record["pair:endDate"]) {
+          if (
+            isSameDay(
+              new Date(record["pair:startDate"]),
+              new Date(record["pair:endDate"])
+            )
+          ) {
+            // Same day : Le xx/xx/xxxx de tt:tt à tt:tt
+            return `Le\xa0${format(
+              new Date(record["pair:startDate"]),
+              "dd/MM/yyyy"
+            )} de\xa0${format(
+              new Date(record["pair:startDate"]),
+              "kk:mm"
+            )}\xa0à\xa0${format(new Date(record["pair:endDate"]), "kk:mm")}`;
+          } else {
+            // Different days : Du xx/xx/xxxx tt:tt au xx/xx/xxxx tt:tt
+            return `Du\xa0${format(
+              new Date(record["pair:startDate"]),
+              "dd/MM/yyyy\xa0kk:mm"
+            )} au\xa0${format(
+              new Date(record["pair:endDate"]),
+              "dd/MM/yyyy\xa0kk:mm"
+            )}`;
+          }
+        }
+        if (record["pair:startDate"]) {
+          // Only start day indicated : La xx/xx/xxxx à tt:tt
+          return `Le\xa0${format(
+            new Date(record["pair:startDate"]),
+            "dd/MM/yyyy"
+          )}\xa0à\xa0${format(new Date(record["pair:startDate"]), "kk:mm")}`;
+        }
+        return "";
+      }}
+      leftAvatar={() => (
         <Avatar width="100%">
           <EventIcon />
         </Avatar>
-      }
+      )}
       linkType="show"
     />
   </List>

--- a/frontend/src/resources/Event/EventShow.js
+++ b/frontend/src/resources/Event/EventShow.js
@@ -1,6 +1,12 @@
 import React from 'react';
-import { UrlField, DateField } from 'react-admin';
-import { Hero, Show, MainList, MarkdownField } from '@semapps/archipelago-layout';
+import { UrlField, DateField, TextField } from 'react-admin';
+import { ReferenceField } from '@semapps/semantic-data-provider';
+import {
+  Hero,
+  Show,
+  MainList,
+  MarkdownField,
+} from '@semapps/archipelago-layout';
 import EventTitle from './EventTitle';
 
 const EventShow = props => (
@@ -9,6 +15,13 @@ const EventShow = props => (
       <Hero>
         <DateField source="pair:startDate" showTime />
         <DateField source="pair:endDate" showTime />
+        <ReferenceField
+          reference="Organization"
+          source="pair:operatedBy"
+          linkType="show"
+        >
+          <TextField source="pair:label" />
+        </ReferenceField>
         <UrlField source="cd:registrationPage" />
         <UrlField source="cd:meetingPage" />
       </Hero>

--- a/frontend/src/resources/Event/index.js
+++ b/frontend/src/resources/Event/index.js
@@ -33,6 +33,7 @@ export default {
         'pair:hasLocation': 'Adresse physique',
         'pair:involves': 'Participants',
         'pair:hasTopic': 'Thèmes',
+        'pair:operatedBy': 'Organisateur',
         'cd:registrationPage': 'Lien inscription',
         'cd:meetingPage': 'Lien visio',
       }

--- a/frontend/src/resources/Organization/OrganizationCreate.js
+++ b/frontend/src/resources/Organization/OrganizationCreate.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { Create } from "@semapps/archipelago-layout";
+import OrganizationForm from "./OrganizationForm";
+
+export const OrganizationCreate = (props) => (
+  <Create {...props}>
+    <OrganizationForm mode="create" />
+  </Create>
+);
+
+export default OrganizationCreate;

--- a/frontend/src/resources/Organization/OrganizationEdit.js
+++ b/frontend/src/resources/Organization/OrganizationEdit.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { Edit } from "@semapps/archipelago-layout";
+import OrganizationTitle from "./OrganizationTitle";
+import OrganizationForm from "./OrganizationForm";
+
+export const OrganizationEdit = (props) => (
+  <Edit title={<OrganizationTitle />} {...props}>
+    <OrganizationForm mode="edit" />
+  </Edit>
+);
+
+export default OrganizationEdit;

--- a/frontend/src/resources/Organization/OrganizationForm.js
+++ b/frontend/src/resources/Organization/OrganizationForm.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { SimpleForm, TextInput, required } from "react-admin";
+import MarkdownInput from "../../markdown/MarkdownInput";
+
+export const OrganizationForm = ({ mode, ...rest }) => (
+  <SimpleForm {...rest} redirect="show">
+    <TextInput source="pair:label" validate={required()} fullWidth />
+    <TextInput source="pair:webPage" fullWidth />
+    <MarkdownInput source="pair:description" fullWidth />
+  </SimpleForm>
+);
+
+export default OrganizationForm;

--- a/frontend/src/resources/Organization/OrganizationList.js
+++ b/frontend/src/resources/Organization/OrganizationList.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { List, SimpleList, ListActions } from "@semapps/archipelago-layout";
+import { Avatar } from "@material-ui/core";
+import AccountBalanceIconIcon from "@material-ui/icons/AccountBalance";
+
+const OrganizationList = (props) => (
+  <List
+    title=""
+    sort={{ field: "pair:label", order: "DESC" }}
+    perPage={100}
+    pagination={false}
+    actions={<ListActions exporter={false} />}
+    {...props}
+  >
+    <SimpleList
+      primaryText={(record) => record["pair:label"]}
+      leftAvatar={() => (
+        <Avatar width="100%">
+          <AccountBalanceIconIcon />
+        </Avatar>
+      )}
+      linkType="show"
+    />
+  </List>
+);
+
+export default OrganizationList;

--- a/frontend/src/resources/Organization/OrganizationShow.js
+++ b/frontend/src/resources/Organization/OrganizationShow.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { TextField, UrlField } from "react-admin";
+import {
+  Hero,
+  Show,
+  MainList,
+  MarkdownField,
+} from "@semapps/archipelago-layout";
+import OrganizationTitle from "./OrganizationTitle";
+
+const OrganizationShow = (props) => (
+  <Show title={<OrganizationTitle />} {...props}>
+    <Hero>
+      <TextField source="pair:label" />
+      <UrlField source="pair:webPage" />
+    </Hero>
+    <MainList>
+      <MarkdownField source="pair:description" />
+    </MainList>
+  </Show>
+);
+
+export default OrganizationShow;

--- a/frontend/src/resources/Organization/OrganizationShow.js
+++ b/frontend/src/resources/Organization/OrganizationShow.js
@@ -1,21 +1,13 @@
 import React from "react";
-import { TextField, UrlField } from "react-admin";
-import {
-  Hero,
-  Show,
-  MainList,
-  MarkdownField,
-} from "@semapps/archipelago-layout";
+import { UrlField } from "react-admin";
+import { Show, MainList, MarkdownField } from "@semapps/archipelago-layout";
 import OrganizationTitle from "./OrganizationTitle";
 
 const OrganizationShow = (props) => (
   <Show title={<OrganizationTitle />} {...props}>
-    <Hero>
-      <TextField source="pair:label" />
-      <UrlField source="pair:webPage" />
-    </Hero>
     <MainList>
       <MarkdownField source="pair:description" />
+      <UrlField source="pair:webPage" />
     </MainList>
   </Show>
 );

--- a/frontend/src/resources/Organization/OrganizationTitle.js
+++ b/frontend/src/resources/Organization/OrganizationTitle.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const OrganizationTitle = ({ record }) => {
+  return <span>{record ? record["pair:label"] : ""}</span>;
+};
+
+export default OrganizationTitle;

--- a/frontend/src/resources/Organization/index.js
+++ b/frontend/src/resources/Organization/index.js
@@ -1,0 +1,33 @@
+import OrganizationCreate from "./OrganizationCreate";
+import OrganizationEdit from "./OrganizationEdit";
+import OrganizationList from "./OrganizationList";
+import OrganizationShow from "./OrganizationShow";
+import AccountBalanceIcon from "@material-ui/icons/AccountBalance";
+
+export default {
+  config: {
+    list: OrganizationList,
+    show: OrganizationShow,
+    create: OrganizationCreate,
+    edit: OrganizationEdit,
+    icon: AccountBalanceIcon,
+    options: {
+      label: "Organizations",
+    },
+  },
+  dataModel: {
+    types: ["pair:organizationOfMembership"],
+    containerUri: process.env.REACT_APP_MIDDLEWARE_URL + "organizations",
+    slugField: ["pair:label"],
+  },
+  translations: {
+    fr: {
+      name: "Organisation |||| Organisations",
+      fields: {
+        "pair:label": "Nom",
+        "pair:description": "Description",
+        "pair:webPage": "Lien vers le site internet ou le blog",
+      },
+    },
+  },
+};

--- a/frontend/src/resources/Organization/index.js
+++ b/frontend/src/resources/Organization/index.js
@@ -16,7 +16,7 @@ export default {
     },
   },
   dataModel: {
-    types: ["pair:organizationOfMembership"],
+    types: ["pair:Organization"],
     containerUri: process.env.REACT_APP_MIDDLEWARE_URL + "organizations",
     slugField: ["pair:label"],
   },

--- a/frontend/src/resources/index.js
+++ b/frontend/src/resources/index.js
@@ -1,6 +1,7 @@
-export { default as Document } from './Document';
-export { default as Event } from './Event';
-export { default as Person } from './Person';
-export { default as Place } from './Place';
-export { default as Page } from './Page';
-export { default as Type } from './Type';
+export { default as Document } from "./Document";
+export { default as Event } from "./Event";
+export { default as Person } from "./Person";
+export { default as Place } from "./Place";
+export { default as Page } from "./Page";
+export { default as Type } from "./Type";
+export { default as Organization } from "./Organization";

--- a/middleware/containers.js
+++ b/middleware/containers.js
@@ -6,7 +6,7 @@ module.exports = [
   {
     path: '/events',
     acceptedTypes: 'pair:Event',
-    dereference: ['pair:hasLocation/pair:hasPostalAddress']
+    dereference: ['pair:hasLocation/pair:hasPostalAddress', 'pair:operatedBy']
   },
   {
     path: '/places',

--- a/middleware/containers.js
+++ b/middleware/containers.js
@@ -6,7 +6,7 @@ module.exports = [
   {
     path: '/events',
     acceptedTypes: 'pair:Event',
-    dereference: ['pair:hasLocation/pair:hasPostalAddress', 'pair:operatedBy']
+    dereference: ['pair:hasLocation/pair:hasPostalAddress']
   },
   {
     path: '/places',
@@ -53,7 +53,7 @@ module.exports = [
   },
   {
     path: '/organizations',
-    acceptedTypes: 'pair:organizationOfMembership'
+    acceptedTypes: 'pair:Organization'
   },
   {
     path: '/pages'

--- a/middleware/containers.js
+++ b/middleware/containers.js
@@ -52,6 +52,10 @@ module.exports = [
     ]
   },
   {
+    path: '/organizations',
+    acceptedTypes: 'pair:organizationOfMembership'
+  },
+  {
     path: '/pages'
   },
   {


### PR DESCRIPTION
## Les grandes lignes de modifications:

 - J'utilise la relation `pair:operatedBy` pour relier un événement (Webinaire) à une organization
 - Les organizations sont du type `pair:organizationOfMembership` Sémentiquement, c'est ce que j'ai trouvé de plus cohérent
 - Les organisations sont accessible à partir le la page `/Organization`. Mais les utilisateurs les créeront grace à un quick create dans le formulaire de `Event`.
 
## La page d'une organisation (titre, lien et description en markdown)
![image](https://user-images.githubusercontent.com/45398769/118408541-5140b480-b686-11eb-8260-a0844bcc23ae.png)

## L'interface pour créer une organisation
![image](https://user-images.githubusercontent.com/45398769/118408239-fb1f4180-b684-11eb-8ed8-aa7921785347.png)

## la liste des webinaire filtrable par organisation associée
![image](https://user-images.githubusercontent.com/45398769/118408329-6f59e500-b685-11eb-825c-ada12f372857.png)


